### PR TITLE
Fix config file loading due to lack of permissions

### DIFF
--- a/pulpcore/cli/common/__init__.py
+++ b/pulpcore/cli/common/__init__.py
@@ -57,6 +57,8 @@ def _config_callback(ctx: click.Context, param: Any, value: Optional[str]) -> No
                             config[key] = new_config[key]
                 except FileNotFoundError:
                     pass
+                except PermissionError:
+                    pass
         profile: str = "cli"
         if PROFILE_KEY in ctx.meta:
             profile = "cli-" + ctx.meta[PROFILE_KEY]


### PR DESCRIPTION
Fix config file loading on systems where one of the config paths is not accessible due to lack of permissions. Fixes #509.

Please be sure you have read our documentation on code contributions:
https://docs.pulpproject.org/pulp_cli/contributing/#code-conventions
